### PR TITLE
Add an example with emphasis on the importance of elision and copy/move

### DIFF
--- a/examples/constructors_destructors_elision/CMakeLists.txt
+++ b/examples/constructors_destructors_elision/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(
+  most_vexing_parse
+  LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+
+set(SRCS example.cpp)
+
+add_executable(${PROJECT_NAME}_example ${SRCS})
+
+target_compile_options(${PROJECT_NAME}_example PRIVATE -fno-elide-constructors)
+

--- a/examples/constructors_destructors_elision/README.md.txt
+++ b/examples/constructors_destructors_elision/README.md.txt
@@ -1,0 +1,7 @@
+
+# Example summary
+
+This example is meant to hammer why we care so much about copy vs move, and what the effect of elision is:
+
+- Even simple sentences can construct and destruct lots of temporary values.
+- Elision is not a minor language feature.

--- a/examples/constructors_destructors_elision/example.cpp
+++ b/examples/constructors_destructors_elision/example.cpp
@@ -51,7 +51,7 @@ class Object {
 };
 
 int main() {
-  cout << "For this exmaple, build with and without -fno-elide-constructors" << endl;
+  cout << "For this example, build with and without -fno-elide-constructors" << endl;
 
   cout << endl;
   cout << "Creation of objects objects" << endl;

--- a/examples/constructors_destructors_elision/example.cpp
+++ b/examples/constructors_destructors_elision/example.cpp
@@ -74,7 +74,7 @@ int main() {
   AB = A + B;
 
   cout << endl;
-  cout << "Quadrulple summation, can you follow what's going on?" << endl;
+  cout << "Quadruple summation, can you follow what's going on?" << endl;
   Object ABCD;
   ABCD = A + B + C + D;
 

--- a/examples/constructors_destructors_elision/example.cpp
+++ b/examples/constructors_destructors_elision/example.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+static std::string op_prefix{" "};
+
+class Object {
+ public:
+  // default constructor
+  Object() {}
+  // direct constructor
+  Object(const std::string id) : id_(id) { cout << op_prefix << "Direct construction of " << id_ << endl; }
+  // copy constructor
+  Object(const Object &source) {
+    id_ = source.id_;
+    cout << op_prefix << "Copy construction of " << id_ << endl;
+  }
+  // move constructor
+  Object(Object &&source) {
+    id_ = source.id_;
+    cout << op_prefix << "Move construction of " << id_ << endl;
+    source.id_ = "empty object (was " + source.id_ + ")";
+  }
+  // copy assignment
+  Object &operator=(const Object &source) {
+    id_ = source.id_;
+    cout << op_prefix << "Copy assignment of " << id_ << endl;
+    return *this;
+  }
+  // move assignment
+  Object &operator=(Object &&source) {
+    id_ = source.id_;
+    cout << op_prefix << "Move assignment of " << id_ << endl;
+    source.id_ = "empty object (was " + source.id_ + ")";
+    return *this;
+  }
+  // Destructor
+  ~Object() { std::cout << op_prefix << "Destruction of " << id_ << std::endl; }
+
+  Object operator+(const Object &b) {
+    auto new_id = id_ + "+" + b.id_;
+    cout << op_prefix << "Summation of " << id_ << " and " << b.id_ << endl;
+    return Object(new_id);
+  }
+
+  std::string getId() const { return id_; }
+
+ private:
+  std::string id_;
+};
+
+int main() {
+  cout << "For this exmaple, build with and without -fno-elide-constructors" << endl;
+
+  cout << endl;
+  cout << "Creation of objects objects" << endl;
+  Object A("A");
+  Object B("B");
+  Object C("C");
+  Object D("D");
+
+  cout << endl;
+  cout << "The following object gets created in a private scope" << endl;
+  { Object X("X"); }
+
+  cout << endl;
+  cout << "How many objects do you see here? Try with and without elision." << endl;
+  { Object X(Object(Object(Object("X")))); }
+
+  cout << endl;
+  cout << "Simple summation, can you follow what's going on?" << endl;
+  Object AB;
+  AB = A + B;
+
+  cout << endl;
+  cout << "Quadrulple summation, can you follow what's going on?" << endl;
+  Object ABCD;
+  ABCD = A + B + C + D;
+
+  cout << endl;
+  cout << "How is this different from before?" << endl;
+  ABCD = (A + B) + (C + D);
+
+  cout << endl;
+  cout << "Exiting program" << endl;
+  return 0;
+}


### PR DESCRIPTION

# Example summary

This example is meant to hammer why we care so much about copy vs move, and what the effect of elision is:

- Even simple sentences can construct and destruct lots of temporary values.
- Elision is not a minor language feature.

Running example: https://godbolt.org/z/P58azW
